### PR TITLE
Update epoll.cpp

### DIFF
--- a/dstore/network/epoll.cpp
+++ b/dstore/network/epoll.cpp
@@ -8,8 +8,8 @@
 using namespace dstore::common;
 using namespace dstore::network;
 
-EpollAPI::EpollAPI(EventLoop *loop)
-  : epfd_(0), events_(nullptr), loop_size_(0), loop_(loop)
+EpollAPI::EpollAPI(EventLoop *lop)
+  : epfd_(0), events_(nullptr), loop_size_(0), loop_(lop)
 {
 }
 


### PR DESCRIPTION
变量定义为loop会出现error: declaration of ‘loop’ shadows a member of 'this'的错误。